### PR TITLE
Move setup outside useEffect hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,9 @@ import lax from 'lax.js';
 import * as React from 'react';
 
 function useLax() {
-  React.useEffect(() => {
-    lax.setup();
+  lax.setup();
 
+  React.useEffect(() => {
     const updateLax = () => {
       lax.update(window.scrollY);
     };


### PR DESCRIPTION
The setup should be executed outside the useEffect method. Because the parent can in some cases be mounted after the child. In this case the lax.elements is reset in the setup function.