### PR TITLE
fix: update useLax hook to be compatible with latest version of lax.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ React hook to use with [lax.js](https://github.com/alexfoxy/laxxx).
 
 ```javascript
 import React from 'react';
-import { useLax, useLaxElement } from 'use-lax';
+import { useLax } from 'use-lax';
 
 function App() {
   const [showBubble, setBubble] = React.useState(false);
@@ -31,11 +31,10 @@ function App() {
 }
 
 function Bubble() {
-  const ref = useLaxElement(); // use it in every component you want to animate
+  // add `lax` in the className attribute and the data-lax-preset attribute
+  // on every component that you want to animate
 
-  return (
-    <div ref={ref} className="bubble" data-lax-preset="leftToRight fadeInOut" />
-  );
+  return <div className="lax bubble" data-lax-preset="leftToRight fadeInOut" />;
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,37 +2,24 @@ import lax from 'lax.js';
 import * as React from 'react';
 
 function useLax() {
-  lax.setup();
+  const requestRef = React.useRef<number>();
 
   React.useEffect(() => {
+    lax.setup();
+
     const updateLax = () => {
       lax.update(window.scrollY);
+      requestRef.current = window.requestAnimationFrame(updateLax);
     };
 
-    document.addEventListener('scroll', updateLax, false);
-
-    updateLax();
+    requestRef.current = window.requestAnimationFrame(updateLax);
 
     return () => {
-      document.removeEventListener('scroll', updateLax);
+      if (requestRef.current) {
+        window.cancelAnimationFrame(requestRef.current);
+      }
     };
   }, []);
 }
 
-function useLaxElement() {
-  const ref = React.useRef();
-
-  React.useEffect(() => {
-    const currentNode = ref.current;
-
-    lax.addElement(currentNode);
-
-    return () => {
-      lax.removeElement(currentNode);
-    };
-  }, []);
-
-  return ref;
-}
-
-export { useLax, useLaxElement };
+export { useLax };


### PR DESCRIPTION
BREAKING CHANGE:

Only one hook is exported - useLax. This hook should be used in the top component.

Closes #72.