### PR TITLE
feat: support breakpoints and className options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ function App() {
     setBubble(!showBubble);
   };
 
-  useLax(); // use once in the top level element
+  // use once in the top level element
+  // you can configure breakpoints and className
+  // useLax({ className: 'nice' });
+  useLax();
 
   return (
     <div>
@@ -31,16 +34,13 @@ function App() {
 }
 
 function Bubble() {
-  const ref = useLaxElement(); // use it in every component added dynamically
+  // use it in every component added dynamically
+  // it will add the className passed to `useLax`, which defaults to `lax`
+  const ref = useLaxElement();
 
-  // add `lax` in the className attribute and the data-lax-preset attribute
-  // on every component that you want to animate
+  // `lax` (or `nice` in our example) will be added to the classList of the element
   return (
-    <div
-      ref={ref}
-      className="lax bubble"
-      data-lax-preset="leftToRight fadeInOut"
-    />
+    <div ref={ref} className="bubble" data-lax-preset="leftToRight fadeInOut" />
   );
 }
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,19 @@
 import lax from 'lax.js';
 import * as React from 'react';
 
-function useLax() {
+interface LaxSetupOptions {
+  breakpoints?: { [k: string]: any };
+  className?: string;
+}
+
+let selector = 'lax';
+
+function useLax({ breakpoints, className }: LaxSetupOptions = {}) {
   const requestRef = React.useRef<number>();
+  selector = className || selector;
 
   React.useEffect(() => {
-    lax.setup();
+    lax.setup({ breakpoints, selector: `.${selector}` });
 
     const updateLax = () => {
       lax.update(window.scrollY);
@@ -19,14 +27,18 @@ function useLax() {
         window.cancelAnimationFrame(requestRef.current);
       }
     };
-  }, []);
+  }, [breakpoints, className]);
 }
 
-function useLaxElement<T>() {
-  const ref = React.useRef<T>();
+function useLaxElement() {
+  const ref = React.useRef<Element>();
 
   React.useEffect(() => {
     const currentNode = ref.current;
+
+    if (currentNode && currentNode.classList) {
+      currentNode.classList.add(selector);
+    }
 
     lax.addElement(currentNode);
 


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a bug fix, feature, docs update, ... -->

**What kind of change does this PR introduce?**
Feature.
<!-- You can also link to an open issue here -->

**What is the current behavior?**
We are not supporting the options that `lax.js` support: `breakpoints` and `selector`.
<!-- if this is a feature change -->

**What is the new behavior?**
- We support a `breakpoints` attribute and pass it down to `lax.js`;
- We support a `className` attribute that will be passed down to `lax.js` **and** applied to all elements added dynamically - using `useLaxElement`. Defaults to `lax` like the library does.
  - **PS: The elements not using the hook must have the className added manually.**
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->